### PR TITLE
Handle sass errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var imp        = require('postcss-import');
 function processSass (obs, opts, ctx) {
     return ctx.vfs.src(opts.input)
         .pipe(sourcemaps.init())
-        .pipe(sass())
+        .pipe(sass().on('error', sass.logError))
         .pipe(post([imp, pre, cssnano]))
         .pipe(sourcemaps.write('.'))
         .pipe(ctx.vfs.dest(opts.output));


### PR DESCRIPTION
Prevents crossbow from exiting a watch process when it runs into a Sass compilation error.
